### PR TITLE
Pass index and original array in .filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,8 @@ export const move = (array, fromIndex, toIndex) => {
 
 export const filter = (array, fn) => {
   let changed = false;
-  const newArray = array.filter(row => {
-    const shouldKeep = fn(row);
+  const newArray = array.filter((row, index, originalArray) => {
+    const shouldKeep = fn(row, index, originalArray);
     changed = !shouldKeep || changed;
     return shouldKeep;
   });

--- a/test.js
+++ b/test.js
@@ -125,6 +125,13 @@ test('filter()', t => {
   t.deepEqual(actual, expected);
 });
 
+test('filter() unique values', t => {
+  const input = [1, 1, 2, 3];
+  const actual = filter(input, (value, index, originalArray) => originalArray.indexOf(value) === index);
+  const expected = [1, 2, 3];
+  t.deepEqual(actual, expected);
+});
+
 test('default import', t => {
   t.is(arrayMethods.push, push);
   t.is(arrayMethods.unshift, unshift);


### PR DESCRIPTION
Review: @kesla 
Type: Minor

Adds index and original array to callback parameters in `.filter()`, to be compatible with standard js `array.filter`.